### PR TITLE
/Change/Set/Status Transform Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+build
+dist
+*.egg-info
+*.pyc
+*.pyo

--- a/ZenPacks/community/deviceAdvDetail/objects/objects.xml
+++ b/ZenPacks/community/deviceAdvDetail/objects/objects.xml
@@ -3,22 +3,12 @@
 <!-- ('', 'zport', 'dmd', 'Events', 'Change', 'Set', 'Status') -->
 <object id='/zport/dmd/Events/Change/Set/Status' module='Products.ZenEvents.EventClass' class='EventClass'>
 <property type="text" id="transform" mode="w" >
-if evt.firstTime == evt.lastTime and hasattr(evt, 'compClass'):
-     for comp in device.getMonitoredComponents(type=evt.compClass):
-        if comp.id != evt.component: continue
-        comp.status = int(evt.compStatus)
-        from transaction import commit
-        commit()
-        break
+from ZenPacks.community.deviceAdvDetail import transforms
+transforms.processEvent(evt, device)
 </property>
 <property type="text" id="transform" mode="w" >
-if evt.firstTime == evt.lastTime and hasattr(evt, 'compClass'):
-     for comp in device.getMonitoredComponents(type=evt.compClass):
-        if comp.id != evt.component: continue
-        comp.status = int(evt.compStatus)
-        from transaction import commit
-        commit()
-        break
+from ZenPacks.community.deviceAdvDetail import transforms
+transforms.processEvent(evt, device)
 </property>
 <property visible="True" type="string" id="zEventAction" >
 status

--- a/ZenPacks/community/deviceAdvDetail/transforms.py
+++ b/ZenPacks/community/deviceAdvDetail/transforms.py
@@ -1,0 +1,28 @@
+################################################################################
+#
+# This program is part of the deviceAdvDetail Zenpack for Zenoss.
+# Copyright (C) 2008, 2009, 2010 Egor Puzanov.
+#
+# This program can be used under the GNU General Public License version 2
+# You can find full information here: http://www.zenoss.com/oss
+#
+################################################################################
+
+from ZODB.transact import transact
+
+
+@transact
+def processEvent(evt, device):
+    if not device:
+        return
+
+    if hasattr(evt, 'compClass') and hasattr(evt, 'compStatus'):
+        for comp in device.getMonitoredComponents(type=evt.compClass):
+            if comp.id != evt.component:
+                continue
+
+            new_status = int(round(float(evt.compStatus)))
+            if comp.status != new_status:
+                comp.status = new_status
+
+            break

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # or saved.  Do not modify them directly here.
 # NB: PACKAGES is deprecated
 NAME = "ZenPacks.community.deviceAdvDetail"
-VERSION = "2.7.3"
+VERSION = "2.8.0"
 AUTHOR = "Egor Puzanov"
 LICENSE = ""
 NAMESPACE_PACKAGES = ['ZenPacks', 'ZenPacks.community']


### PR DESCRIPTION
Please pull these changes. I changed the implementation of the transform to work on Zenoss 2 - 4 and moved it into an external module so that I could wrap it in a @transact decorator. This safely handles ConflictErrors when the status is changed on the model.
